### PR TITLE
Remove getRoleId from ZfcUserAcl\Model\RoleInterface

### DIFF
--- a/src/ZfcUserAcl/Model/RoleInterface.php
+++ b/src/ZfcUserAcl/Model/RoleInterface.php
@@ -6,7 +6,6 @@ use Zend\Acl\Role\RoleInterface as ZfRoleInterface;
 
 interface RoleInterface extends ZfRoleInterface
 {
-    public function getRoleId();
     public function setRoleId($roleId);
  
     public function getDefault();


### PR DESCRIPTION
The method `getRoleId` is already defined in `Zend\Acl\Role\RoleInterface`, and so defining it again in `ZfcUserAcl\Model\RoleInterface` raises a fatal error:

```
Fatal error: Can't inherit abstract function Zend\Acl\Role\RoleInterface::getRoleId() (previously declared abstract in ZfcUserAcl\Model\RoleInterface) in src/ZfcUserAcl/Model/RoleInterface.php on line 8
```
